### PR TITLE
Add support for IE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .vscode/
 npm-debug.log
 build
+yarn.lock

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ function install(editor, { type, transformer, arrow, curve, options = {} }) {
             const marker = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
             el.querySelector('svg').appendChild(marker);
-            marker.classList = 'marker';
+            marker.classList.add('marker');
             marker.setAttribute('fill', arrow.color || 'steelblue');
             marker.setAttribute('d', arrow.marker || 'M-5,-10 L-5,10 L20,0 z');
 


### PR DESCRIPTION
IE does not support the assignment of values in read-only objects in "strict mode", so it is better to use the "add" function to add the "marker" class, it also remains compatible in all web browsers.